### PR TITLE
fix string index out of range in local.py line 107

### DIFF
--- a/local.py
+++ b/local.py
@@ -103,7 +103,7 @@ class Socks5Server(SocketServer.StreamRequestHandler):
             sock = self.connection
             sock.recv(262)
             sock.send("\x05\x00")
-            data = self.rfile.read(4)
+            data = self.rfile.read(4) or '\x00' * 4
             mode = ord(data[1])
             if mode != 1:
                 logging.warn('mode != 1')


### PR DESCRIPTION
Hi,

When local client close socks5 connection the local.py will receive zero length `data` 

This is the error:

```
Exception happened during processing of request from ('192.x.x.x', 62856)
Traceback (most recent call last):
  File "/usr/lib/python2.6/SocketServer.py", line 558, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python2.6/SocketServer.py", line 320, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.6/SocketServer.py", line 615, in __init__
    self.handle()
  File "local.py", line 107, in handle
    mode = ord(data[1])
IndexError: string index out of range
----------------------------------------
```

This small patch fix this problem :D
