### PR TITLE
Use single-thread non-blocking asynchronous model w/ Tornado

### DIFF
--- a/server.py
+++ b/server.py
@@ -115,7 +115,7 @@ class ConnHandler(PairedStream):
     def on_remote_connected(self):
         self.read_until_close(callback=self.on_client_read, streaming_callback=self.on_client_read)
         self.remote.read_until_close(callback=self.on_remote_read, streaming_callback=self.on_remote_read)
-        self._read_from_buffer()  # We must call this to empty filled buffer otherwise nothing will be read in again.
+        self._try_inline_read()  # We must call this to empty filled buffer otherwise nothing will be read in again.
 
     def on_client_read(self, data):
         if data and not self.remote.closed():


### PR DESCRIPTION
Thread model of Python w/ version before 3.2 is buggy. See http://www.dabeaz.com/python/GIL.pdf
Also gevent is buggy too. See http://blog.gevent.org/2011/04/28/libev-and-libevent/
So i rewrite the server side code using tornado to solve the related problems.
I'm using this only in Android phones, so i don't have time to rewrite the client-side script.
The PR introduces the dependence of tornado. You can bundle tornado to solve the issue.
