### PR TITLE
Support python 2.5 for client

### DIFF
--- a/local.py
+++ b/local.py
@@ -37,7 +37,6 @@ import struct
 import string
 import hashlib
 import os
-import json
 import logging
 import getopt
 


### PR DESCRIPTION
- Use simplejson instead of json module
- Add with feature in Python 2.5
