### PR TITLE
exit quietly with KeyboardInterrupt

### DIFF
--- a/local.py
+++ b/local.py
@@ -190,4 +190,7 @@ if __name__ == '__main__':
         server.serve_forever()
     except socket.error, e:
         logging.error(e)
+    except KeyboardInterrupt:
+        server.shutdown()
+        sys.exit(0)
 


### PR DESCRIPTION
if user presses ctrl+C while TCP server's running, nothing happens. with this patch it shuts down the server and exits.
