### PR TITLE
Update m2crypto installation for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ Install Shadowsocks.
 
 #### OS X:
 
-    git clone https://github.com/clowwindy/M2Crypto.git
-    cd M2Crypto
-    pip install .
+    pip install M2Crypto
     pip install shadowsocks
 
 #### Windows:


### PR DESCRIPTION
Use pip sources to install m2crypto so that users can get further upgrades.
