### PR TITLE
avoid memory leak

### DIFF
--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -184,7 +184,7 @@ class EventLoop(object):
 
     def remove(self, f):
         fd = f.fileno()
-        self._fd_to_f[fd] = None
+        del self._fd_to_f[fd]
         self._impl.remove_fd(fd)
 
     def modify(self, f, mode):


### PR DESCRIPTION
Although fd is always the smallest number which haven't been allocated, which means memory leak is quite small. but the worst situation may consume lots of memory.
