### PR TITLE
setup.py: use codecs.open() so it works for non-utf8 locales

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
+import codecs
 from setuptools import setup
 
 
-with open('README.rst') as f:
+with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
When building in a non-utf8 locale, the current `open()` approach in `setup.py` will fail in python 3.x. This PR uses `codecs.open` which works correctly across all versions of python 2.x and 3.x.

Error examples without the patch:

```
$ LANG=C python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    long_description = f.read()
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 115: ordinal not in range(128)
```

```
$ LANG=zh_CN.GBK python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    long_description = f.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 117: illegal multibyte sequence
```
