### PR TITLE
tcprelay.py: decode remote_addr to fix extra b'' in logging on python 3

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -261,7 +261,8 @@ class TCPRelayHandler(object):
             if header_result is None:
                 raise Exception('can not parse header')
             addrtype, remote_addr, remote_port, header_length = header_result
-            logging.info('connecting %s:%d' % (remote_addr.decode('utf-8'), remote_port))
+            logging.info('connecting %s:%d' % (remote_addr.decode('utf-8'),
+                                               remote_port))
             self._remote_address = (remote_addr, remote_port)
             # pause reading
             self._update_stream(STREAM_UP, WAIT_STATUS_WRITING)


### PR DESCRIPTION
On Python 3, `"%s" % a_bytes_variable` will generate outputs like `"b'content'"` instead of just `"content"`. This PR fixes it by always calling `decode` for logging, so both Python 2.x and 3.x will get the same output style.

Before:

```
Nov 01 23:20:03 flygon.felixc.at sslocal[3860]: 2014-11-01 23:20:03 INFO     connecting b'clients4.google.com':443
```

After:

```
Nov 02 00:21:07 flygon.felixc.at sslocal[12885]: 2014-11-02 00:21:07 INFO     connecting clients4.google.com:443
```
