### PR TITLE
Fix str/byte related TypeError in Python 3.4

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -207,7 +207,7 @@ class TCPRelayHandler(object):
                     self._create_remote_socket(self._chosen_server[0],
                                                self._chosen_server[1])
                 self._loop.add(remote_sock, eventloop.POLL_ERR)
-                data = ''.join(self._data_to_write_to_local)
+                data = b''.join(self._data_to_write_to_local)
                 l = len(data)
                 s = remote_sock.sendto(data, MSG_FASTOPEN, self._chosen_server)
                 if s < l:


### PR DESCRIPTION
Traceback (most recent call last):
File "/usr/bin/sslocal", line 9, in <module>
load_entry_point('shadowsocks==2.4', 'console_scripts', 'sslocal')()
File "/usr/lib/python3.4/site-packages/shadowsocks/local.py", line 68, in main
loop.run()
File "/usr/lib/python3.4/site-packages/shadowsocks/eventloop.py", line 230, in run
handler(events)
File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 630, in _handle_events
handler.handle_event(sock, event)
File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 458, in handle_event
self._on_local_read()
File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 377, in _on_local_read
self._handle_stage_reply(data)
File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 212, in _handle_stage_reply
s = remote_sock.sendto(data, MSG_FASTOPEN, self._chosen_server)
TypeError: 'str' does not support the buffer interface
