### PR TITLE
use native string type for option values

### DIFF
--- a/shadowsocks/crypto/ctypes_openssl.py
+++ b/shadowsocks/crypto/ctypes_openssl.py
@@ -66,9 +66,7 @@ def load_openssl():
 
 
 def load_cipher(cipher_name):
-    func_name = b'EVP_' + cipher_name.replace(b'-', b'_')
-    if bytes != str:
-        func_name = str(func_name, 'utf-8')
+    func_name = 'EVP_' + cipher_name.replace('-', '_')
     cipher = getattr(libcrypto, func_name, None)
     if cipher:
         cipher.restype = c_void_p
@@ -119,31 +117,31 @@ class CtypesCrypto(object):
 
 
 ciphers = {
-    b'aes-128-cfb': (16, 16, CtypesCrypto),
-    b'aes-192-cfb': (24, 16, CtypesCrypto),
-    b'aes-256-cfb': (32, 16, CtypesCrypto),
-    b'aes-128-ofb': (16, 16, CtypesCrypto),
-    b'aes-192-ofb': (24, 16, CtypesCrypto),
-    b'aes-256-ofb': (32, 16, CtypesCrypto),
-    b'aes-128-ctr': (16, 16, CtypesCrypto),
-    b'aes-192-ctr': (24, 16, CtypesCrypto),
-    b'aes-256-ctr': (32, 16, CtypesCrypto),
-    b'aes-128-cfb8': (16, 16, CtypesCrypto),
-    b'aes-192-cfb8': (24, 16, CtypesCrypto),
-    b'aes-256-cfb8': (32, 16, CtypesCrypto),
-    b'aes-128-cfb1': (16, 16, CtypesCrypto),
-    b'aes-192-cfb1': (24, 16, CtypesCrypto),
-    b'aes-256-cfb1': (32, 16, CtypesCrypto),
-    b'bf-cfb': (16, 8, CtypesCrypto),
-    b'camellia-128-cfb': (16, 16, CtypesCrypto),
-    b'camellia-192-cfb': (24, 16, CtypesCrypto),
-    b'camellia-256-cfb': (32, 16, CtypesCrypto),
-    b'cast5-cfb': (16, 8, CtypesCrypto),
-    b'des-cfb': (8, 8, CtypesCrypto),
-    b'idea-cfb': (16, 8, CtypesCrypto),
-    b'rc2-cfb': (16, 8, CtypesCrypto),
-    b'rc4': (16, 0, CtypesCrypto),
-    b'seed-cfb': (16, 16, CtypesCrypto),
+    'aes-128-cfb': (16, 16, CtypesCrypto),
+    'aes-192-cfb': (24, 16, CtypesCrypto),
+    'aes-256-cfb': (32, 16, CtypesCrypto),
+    'aes-128-ofb': (16, 16, CtypesCrypto),
+    'aes-192-ofb': (24, 16, CtypesCrypto),
+    'aes-256-ofb': (32, 16, CtypesCrypto),
+    'aes-128-ctr': (16, 16, CtypesCrypto),
+    'aes-192-ctr': (24, 16, CtypesCrypto),
+    'aes-256-ctr': (32, 16, CtypesCrypto),
+    'aes-128-cfb8': (16, 16, CtypesCrypto),
+    'aes-192-cfb8': (24, 16, CtypesCrypto),
+    'aes-256-cfb8': (32, 16, CtypesCrypto),
+    'aes-128-cfb1': (16, 16, CtypesCrypto),
+    'aes-192-cfb1': (24, 16, CtypesCrypto),
+    'aes-256-cfb1': (32, 16, CtypesCrypto),
+    'bf-cfb': (16, 8, CtypesCrypto),
+    'camellia-128-cfb': (16, 16, CtypesCrypto),
+    'camellia-192-cfb': (24, 16, CtypesCrypto),
+    'camellia-256-cfb': (32, 16, CtypesCrypto),
+    'cast5-cfb': (16, 8, CtypesCrypto),
+    'des-cfb': (8, 8, CtypesCrypto),
+    'idea-cfb': (16, 8, CtypesCrypto),
+    'rc2-cfb': (16, 8, CtypesCrypto),
+    'rc4': (16, 0, CtypesCrypto),
+    'seed-cfb': (16, 16, CtypesCrypto),
 }
 
 

--- a/shadowsocks/crypto/m2.py
+++ b/shadowsocks/crypto/m2.py
@@ -52,19 +52,19 @@ def err(alg, key, iv, op, key_as_bytes=0, d=None, salt=None, i=1, padding=1):
 
 if has_m2:
     ciphers = {
-        b'aes-128-cfb': (16, 16, create_cipher),
-        b'aes-192-cfb': (24, 16, create_cipher),
-        b'aes-256-cfb': (32, 16, create_cipher),
-        b'bf-cfb': (16, 8, create_cipher),
-        b'camellia-128-cfb': (16, 16, create_cipher),
-        b'camellia-192-cfb': (24, 16, create_cipher),
-        b'camellia-256-cfb': (32, 16, create_cipher),
-        b'cast5-cfb': (16, 8, create_cipher),
-        b'des-cfb': (8, 8, create_cipher),
-        b'idea-cfb': (16, 8, create_cipher),
-        b'rc2-cfb': (16, 8, create_cipher),
-        b'rc4': (16, 0, create_cipher),
-        b'seed-cfb': (16, 16, create_cipher),
+        'aes-128-cfb': (16, 16, create_cipher),
+        'aes-192-cfb': (24, 16, create_cipher),
+        'aes-256-cfb': (32, 16, create_cipher),
+        'bf-cfb': (16, 8, create_cipher),
+        'camellia-128-cfb': (16, 16, create_cipher),
+        'camellia-192-cfb': (24, 16, create_cipher),
+        'camellia-256-cfb': (32, 16, create_cipher),
+        'cast5-cfb': (16, 8, create_cipher),
+        'des-cfb': (8, 8, create_cipher),
+        'idea-cfb': (16, 8, create_cipher),
+        'rc2-cfb': (16, 8, create_cipher),
+        'rc4': (16, 0, create_cipher),
+        'seed-cfb': (16, 16, create_cipher),
     }
 else:
     ciphers = {}

--- a/shadowsocks/crypto/rc4_md5.py
+++ b/shadowsocks/crypto/rc4_md5.py
@@ -47,7 +47,7 @@ def create_cipher(alg, key, iv, op, key_as_bytes=0, d=None, salt=None,
 
 
 ciphers = {
-    b'rc4-md5': (16, 16, create_cipher),
+    'rc4-md5': (16, 16, create_cipher),
 }
 
 

--- a/shadowsocks/crypto/salsa20_ctr.py
+++ b/shadowsocks/crypto/salsa20_ctr.py
@@ -123,7 +123,7 @@ class Salsa20Cipher(object):
 
 
 ciphers = {
-    b'salsa20-ctr': (32, 8, Salsa20Cipher),
+    'salsa20-ctr': (32, 8, Salsa20Cipher),
 }
 
 

--- a/shadowsocks/crypto/table.py
+++ b/shadowsocks/crypto/table.py
@@ -73,7 +73,7 @@ class TableCipher(object):
 
 
 ciphers = {
-    b'table': (0, 0, TableCipher)
+    'table': (0, 0, TableCipher)
 }
 
 

--- a/shadowsocks/utils.py
+++ b/shadowsocks/utils.py
@@ -21,19 +21,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import absolute_import, division, print_function, \
-    with_statement
+from __future__ import (
+    absolute_import, division, print_function, with_statement,
+)
 
 import os
 import json
 import sys
 import getopt
 import logging
-from shadowsocks.common import to_bytes
 
 
 VERBOSE_LEVEL = 5
 
+if sys.version_info[0] == 2:
+    import codecs
+    open = codecs.open
 
 def check_python():
     info = sys.version_info
@@ -110,10 +113,9 @@ def get_config(is_local):
 
         if config_path:
             logging.info('loading config from %s' % config_path)
-            with open(config_path, 'rb') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 try:
-                    config = json.loads(f.read().decode('utf8'),
-                                        object_hook=_decode_dict)
+                    config = json.load(f)
                 except ValueError as e:
                     logging.error('found an error in config.json: %s',
                                   e.message)
@@ -127,15 +129,15 @@ def get_config(is_local):
             if key == '-p':
                 config['server_port'] = int(value)
             elif key == '-k':
-                config['password'] = to_bytes(value)
+                config['password'] = value
             elif key == '-l':
                 config['local_port'] = int(value)
             elif key == '-s':
-                config['server'] = to_bytes(value)
+                config['server'] = value
             elif key == '-m':
-                config['method'] = to_bytes(value)
+                config['method'] = value
             elif key == '-b':
-                config['local_address'] = to_bytes(value)
+                config['local_address'] = value
             elif key == '-v':
                 v_count += 1
                 # '-vv' turns on more verbose mode
@@ -271,29 +273,3 @@ optional arguments:
 
 Online help: <https://github.com/clowwindy/shadowsocks>
 ''')
-
-
-def _decode_list(data):
-    rv = []
-    for item in data:
-        if hasattr(item, 'encode'):
-            item = item.encode('utf-8')
-        elif isinstance(item, list):
-            item = _decode_list(item)
-        elif isinstance(item, dict):
-            item = _decode_dict(item)
-        rv.append(item)
-    return rv
-
-
-def _decode_dict(data):
-    rv = {}
-    for key, value in data.items():
-        if hasattr(value, 'encode'):
-            value = value.encode('utf-8')
-        elif isinstance(value, list):
-            value = _decode_list(value)
-        elif isinstance(value, dict):
-            value = _decode_dict(value)
-        rv[key] = value
-    return rv


### PR DESCRIPTION
Let strings be string; those are comprehended as strings.

This fixes for Python 3 users with `method aes-256-cfb not supported` errors.
