### PR TITLE
fix str/byte issue in python 3

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -407,7 +407,7 @@ class TCPRelayHandler(object):
 
     def _on_local_write(self):
         if self._data_to_write_to_local:
-            data = ''.join(self._data_to_write_to_local)
+            data = b''.join(self._data_to_write_to_local)
             self._data_to_write_to_local = []
             self._write_to_sock(data, self._local_sock)
         else:


### PR DESCRIPTION
I'm using python 3.4 in my server, and I found TypeError messages related to string and bytes:

```
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: handler.handle_event(sock, event)
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 463, in handle_event
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: self._on_local_write()
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 412, in _on_local_write
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: self._write_to_sock(data, self._local_sock)
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: File "/usr/lib/python3.4/site-packages/shadowsocks/tcprelay.py", line 165, in _write_to_sock
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: s = sock.send(data)
Nov 10 10:23:33 li570-234.members.linode.com ssserver[3402]: TypeError: 'str' does not support the buffer interface
```

This patch fixes that.
