### PR TITLE
Searching libcrypto.so in more locations

### DIFF
--- a/shadowsocks/crypto/ctypes_openssl.py
+++ b/shadowsocks/crypto/ctypes_openssl.py
@@ -83,9 +83,9 @@ def load_cipher(cipher_name):
 
 class CtypesCrypto(object):
     def __init__(self, cipher_name, key, iv, op):
+        self._ctx = None
         if not loaded:
             load_openssl()
-        self._ctx = None
         cipher = libcrypto.EVP_get_cipherbyname(cipher_name)
         if not cipher:
             cipher = load_cipher(cipher_name)

--- a/shadowsocks/crypto/rc4_md5.py
+++ b/shadowsocks/crypto/rc4_md5.py
@@ -39,7 +39,7 @@ def create_cipher(alg, key, iv, op, key_as_bytes=0, d=None, salt=None,
     try:
         from shadowsocks.crypto import ctypes_openssl
         return ctypes_openssl.CtypesCrypto(b'rc4', rc4_key, b'', op)
-    except:
+    except Exception:
         import M2Crypto.EVP
         return M2Crypto.EVP.Cipher(b'rc4', rc4_key, b'', op,
                                    key_as_bytes=0, d='md5', salt=None, i=1,

--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -234,7 +234,7 @@ class EventLoop(object):
                     traceback.print_exc()
             for handler in self._handlers_to_remove:
                 self._handlers.remove(handler)
-                self._handlers_to_remove = []
+            self._handlers_to_remove = []
             self._iterating = False
 
 


### PR DESCRIPTION
When I tried to setup `ss` server on my host, which was a shared shard, `crypto` searching failed, because `libcrypto.so` was put in `/usr/lib64` rather than `/usr/lib`.

A few minor fixes are also included.