### PR TITLE
Searching libcrypto.so in more locations

### DIFF
--- a/shadowsocks/crypto/ctypes_openssl.py
+++ b/shadowsocks/crypto/ctypes_openssl.py
@@ -83,9 +83,9 @@ def load_cipher(cipher_name):
 
 class CtypesCrypto(object):
     def __init__(self, cipher_name, key, iv, op):
+        self._ctx = None
         if not loaded:
             load_openssl()
-        self._ctx = None
         cipher = libcrypto.EVP_get_cipherbyname(cipher_name)
         if not cipher:
             cipher = load_cipher(cipher_name)

--- a/shadowsocks/crypto/ctypes_openssl.py
+++ b/shadowsocks/crypto/ctypes_openssl.py
@@ -45,8 +45,8 @@ def load_openssl():
         if libcrypto_path:
             break
     else:
-        # We may get here when find_library fails because, for example, 
-        # the user does not have sufficient privileges to access those 
+        # We may get here when find_library fails because, for example,
+        # the user does not have sufficient privileges to access those
         # tools underlying find_library on linux.
 
         import glob

--- a/shadowsocks/crypto/rc4_md5.py
+++ b/shadowsocks/crypto/rc4_md5.py
@@ -39,7 +39,7 @@ def create_cipher(alg, key, iv, op, key_as_bytes=0, d=None, salt=None,
     try:
         from shadowsocks.crypto import ctypes_openssl
         return ctypes_openssl.CtypesCrypto(b'rc4', rc4_key, b'', op)
-    except:
+    except Exception:
         import M2Crypto.EVP
         return M2Crypto.EVP.Cipher(b'rc4', rc4_key, b'', op,
                                    key_as_bytes=0, d='md5', salt=None, i=1,

--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -232,9 +232,10 @@ class EventLoop(object):
                     logging.error(e)
                     import traceback
                     traceback.print_exc()
-            for handler in self._handlers_to_remove:
-                self._handlers.remove(handler)
-            self._handlers_to_remove = []
+            if self._handlers_to_remove:
+                for handler in self._handlers_to_remove:
+                    self._handlers.remove(handler)
+                self._handlers_to_remove = []
             self._iterating = False
 
 

--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -234,7 +234,7 @@ class EventLoop(object):
                     traceback.print_exc()
             for handler in self._handlers_to_remove:
                 self._handlers.remove(handler)
-                self._handlers_to_remove = []
+            self._handlers_to_remove = []
             self._iterating = False
 
 


### PR DESCRIPTION
When I tried to setup `ss` server on my host, which was a shared shard, `crypto` searching failed, because `libcrypto.so` was put in `/usr/lib64` rather than `/usr/lib`.

A few minor fixes are also included.

Change 6eadfca was missing in #256.
