### PR TITLE
将最大的request id设置为65536

### DIFF
--- a/shadowsocks/asyncdns.py
+++ b/shadowsocks/asyncdns.py
@@ -413,7 +413,7 @@ class DNSResolver(object):
 
     def _send_req(self, hostname, qtype):
         self._request_id += 1
-        if self._request_id > 32768:
+        if self._request_id > 65536:
             self._request_id = 1
         req = build_request(hostname, qtype, self._request_id)
         for server in self._servers:


### PR DESCRIPTION
拜读源码的时候发现的这个问题
根据RFC1035第25页 (https://www.ietf.org/rfc/rfc1035.txt)
可以看到request id是一个16位的识别符，严格地说应该也不算是数字，只是识别符。
当作为数字处理的时候，由于每一位都可以发挥识别作用，所以可以看作是无符号数。
那最大值应该可以被设为65536吧？