### PR TITLE
convert remote_address to str so it will be printed more correctly on python 3

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -295,7 +295,7 @@ class TCPRelayHandler(object):
             logging.info('connecting %s:%d from %s:%d' %
                          (common.to_str(remote_addr), remote_port,
                           self._client_address[0], self._client_address[1]))
-            self._remote_address = (remote_addr, remote_port)
+            self._remote_address = (common.to_str(remote_addr), remote_port)
             # pause reading
             self._update_stream(STREAM_UP, WAIT_STATUS_WRITING)
             self._stage = STAGE_DNS


### PR DESCRIPTION
Before: `sslocal[13287]: 2015-02-11 10:09:59 WARNING  timed out: b'1.2.3.4':5223`
After: `sslocal[13478]: 2015-02-11 11:03:31 WARNING  timed out: 1.2.3.4:5223`

The first element of _remote_address tuple was only used for logging, so I guess it won't cause any side effect.