### PR TITLE
remove duplicate code from shell.py

### DIFF
--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -157,7 +157,6 @@ def get_config(is_local):
         else:
             config = {}
 
-        optlist, args = getopt.getopt(sys.argv[1:], shortopts, longopts)
         v_count = 0
         for key, value in optlist:
             if key == '-p':


### PR DESCRIPTION
when read the command line args ,the `getopt()` method be called twice. I think just once will be ok.