### PR TITLE
Add fail2ban filter.

### DIFF
--- a/utils/fail2ban/shadowsocks.conf
+++ b/utils/fail2ban/shadowsocks.conf
@@ -1,0 +1,5 @@
+[Definition]
+
+_daemon = shadowsocks
+
+failregex = ^\s+ERROR\s+can not parse header when handling connection from <HOST>:\d+$


### PR DESCRIPTION
A simple filter for fail2ban, which is a powerful log monitoring tool.

Please put the shadowsocks.conf into your filter.d directory, and
using `filter = shadowsocks` to use the filter.