### PR TITLE
fix bug in tcprelay

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -709,3 +709,4 @@ class TCPRelay(object):
         self._closed = True
         if not next_tick:
             self._server_socket.close()
+            self._server_socket = None


### PR DESCRIPTION
_server_socket closed but not set to empty in close(), will got error in _handle_events()