### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Server
 Debian / Ubuntu:
 
     apt-get install python-pip
-    pip install shadowsocks
+    pip install git+https://github.com/shadowsocks/shadowsocks.git@master
 
 CentOS:
 
     yum install python-setuptools && easy_install pip
-    pip install shadowsocks
+    pip install git+https://github.com/shadowsocks/shadowsocks.git@master
 
 Windows:
 


### PR DESCRIPTION
The shadowsocks in [pypi](https://pypi.python.org/pypi/shadowsocks) is out of date, may install from github@master: 

```
pip install git+https://github.com/shadowsocks/shadowsocks.git@master
```

The wiki also may be changed
