### PR TITLE
Fix a OTA bug on `_ota_chunk_data`

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -458,7 +458,7 @@ class TCPRelayHandler(object):
                     return
                 data_len = self._ota_buff_head[:ONETIMEAUTH_CHUNK_DATA_LEN]
                 self._ota_len = struct.unpack('>H', data_len)[0]
-            length = min(self._ota_len, len(data))
+            length = min(self._ota_len - len(self._ota_buff_data), len(data))
             self._ota_buff_data += data[:length]
             data = data[length:]
             if len(self._ota_buff_data) == self._ota_len:

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -358,7 +358,7 @@ class TCPRelayHandler(object):
                                  b'\x00\x00\x00\x00\x10\x10'),
                                 self._local_sock)
             # spec https://shadowsocks.org/en/spec/one-time-auth.html
-            # ATYP & 0x10 == 1, then OTA is enabled.
+            # ATYP & 0x10 == 0x10, then OTA is enabled.
             if self._ota_enable_session:
                 data = common.chr(addrtype | ADDRTYPE_AUTH) + data[1:]
                 key = self._encryptor.cipher_iv + self._encryptor.key


### PR DESCRIPTION
You can repro it by following code:

```python
from __future__ import print_function
import struct

ONETIMEAUTH_BYTES = 10
ONETIMEAUTH_CHUNK_BYTES = 12
ONETIMEAUTH_CHUNK_DATA_LEN = 2

class OTA(object):
    def __init__(self):
        self._ota_len = 0
        self._ota_chunk_idx = 0
        self._ota_buff_head = b''
        self._ota_buff_data = b''

    def _ota_chunk_data(self, data, data_cb):
        # spec https://shadowsocks.org/en/spec/one-time-auth.html
        unchunk_data = b''
        while len(data) > 0:
            if self._ota_len == 0:
                # get DATA.LEN + HMAC-SHA1
                length = ONETIMEAUTH_CHUNK_BYTES - len(self._ota_buff_head)
                self._ota_buff_head += data[:length]
                data = data[length:]
                if len(self._ota_buff_head) < ONETIMEAUTH_CHUNK_BYTES:
                    # wait more data
                    return
                data_len = self._ota_buff_head[:ONETIMEAUTH_CHUNK_DATA_LEN]
                self._ota_len = struct.unpack('>H', data_len)[0]
            length = min(self._ota_len, len(data))
            self._ota_buff_data += data[:length]
            data = data[length:]
            if len(self._ota_buff_data) == self._ota_len:
                # get a chunk data
                _hash = self._ota_buff_head[ONETIMEAUTH_CHUNK_DATA_LEN:]
                _data = self._ota_buff_data
                index = struct.pack('>I', self._ota_chunk_idx)
                # key = self._encryptor.decipher_iv + index
                # if onetimeauth_verify(_hash, _data, key) is False:
                #     logging.warn('one time auth fail, drop chunk !')
                # else:
                unchunk_data += _data
                self._ota_chunk_idx += 1

                self._ota_buff_head = b''
                self._ota_buff_data = b''
                self._ota_len = 0
        data_cb(unchunk_data)
        return


def test(data):
    print("-" * 40)
    o = OTA()
    for frag in data:
        o._ota_chunk_data(frag, print)

if __name__ == '__main__':
    data1 = [
        b'\x00\x03hhhhhhhhhh111\x00\x03hhhhhhhhhh222',
    ]
    data2 = [
        b'\x00\x03hhhhhhhhhh1',
        b'11\x00\x03hhhhhhhhhh222',
    ]

    test(data1)
    test(data2)
```

The output:

```
----------------------------------------
111222
----------------------------------------


```