### PR TITLE
Convert bad quotes to only single quote

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name="shadowsocks",
-    version="2.8.2",
+    name='shadowsocks',
+    version='2.8.2',
     license='http://www.apache.org/licenses/LICENSE-2.0',
-    description="A fast tunnel proxy that help you get through firewalls",
+    description='A fast tunnel proxy that help you get through firewalls',
     author='clowwindy',
     author_email='clowwindy42@gmail.com',
     url='https://github.com/shadowsocks/shadowsocks',
@@ -18,11 +18,11 @@ setup(
         'shadowsocks': ['README.rst', 'LICENSE']
     },
     install_requires=[],
-    entry_points="""
+    entry_points='''
     [console_scripts]
     sslocal = shadowsocks.local:main
     ssserver = shadowsocks.server:main
-    """,
+    ''',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',

--- a/shadowsocks/asyncdns.py
+++ b/shadowsocks/asyncdns.py
@@ -29,7 +29,7 @@ from shadowsocks import common, lru_cache, eventloop, shell
 
 CACHE_SWEEP_INTERVAL = 30
 
-VALID_HOSTNAME = re.compile(br"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+VALID_HOSTNAME = re.compile(br'(?!-)[A-Z\d-]{1,63}(?<!-)$', re.IGNORECASE)
 
 common.patch_socket()
 

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -111,7 +111,7 @@ def inet_pton(family, addr):
                 break
         return b''.join((chr(i // 256) + chr(i % 256)) for i in dbyts)
     else:
-        raise RuntimeError("What family?")
+        raise RuntimeError('What family?')
 
 
 def is_ip(address):
@@ -210,30 +210,30 @@ class IPNetwork(object):
         list(map(self.add_network, addrs))
 
     def add_network(self, addr):
-        if addr is "":
+        if addr is '':
             return
         block = addr.split('/')
         addr_family = is_ip(block[0])
         addr_len = IPNetwork.ADDRLENGTH[addr_family]
         if addr_family is socket.AF_INET:
-            ip, = struct.unpack("!I", socket.inet_aton(block[0]))
+            ip, = struct.unpack('!I', socket.inet_aton(block[0]))
         elif addr_family is socket.AF_INET6:
-            hi, lo = struct.unpack("!QQ", inet_pton(addr_family, block[0]))
+            hi, lo = struct.unpack('!QQ', inet_pton(addr_family, block[0]))
             ip = (hi << 64) | lo
         else:
-            raise Exception("Not a valid CIDR notation: %s" % addr)
+            raise Exception('Not a valid CIDR notation: %s' % addr)
         if len(block) is 1:
             prefix_size = 0
             while (ip & 1) == 0 and ip is not 0:
                 ip >>= 1
                 prefix_size += 1
-            logging.warn("You did't specify CIDR routing prefix size for %s, "
-                         "implicit treated as %s/%d" % (addr, addr, addr_len))
+            logging.warn('You did\'t specify CIDR routing prefix size for %s, '
+                         'implicit treated as %s/%d' % (addr, addr, addr_len))
         elif block[1].isdigit() and int(block[1]) <= addr_len:
             prefix_size = addr_len - int(block[1])
             ip >>= prefix_size
         else:
-            raise Exception("Not a valid CIDR notation: %s" % addr)
+            raise Exception('Not a valid CIDR notation: %s' % addr)
         if addr_family is socket.AF_INET:
             self._network_list_v4.append((ip, prefix_size))
         else:
@@ -242,11 +242,11 @@ class IPNetwork(object):
     def __contains__(self, addr):
         addr_family = is_ip(addr)
         if addr_family is socket.AF_INET:
-            ip, = struct.unpack("!I", socket.inet_aton(addr))
+            ip, = struct.unpack('!I', socket.inet_aton(addr))
             return any(map(lambda n_ps: n_ps[0] == ip >> n_ps[1],
                            self._network_list_v4))
         elif addr_family is socket.AF_INET6:
-            hi, lo = struct.unpack("!QQ", inet_pton(addr_family, addr))
+            hi, lo = struct.unpack('!QQ', inet_pton(addr_family, addr))
             ip = (hi << 64) | lo
             return any(map(lambda n_ps: n_ps[0] == ip >> n_ps[1],
                            self._network_list_v6))

--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -31,9 +31,9 @@ def find_library_nt(name):
         fname = os.path.join(directory, name)
         if os.path.isfile(fname):
             results.append(fname)
-        if fname.lower().endswith(".dll"):
+        if fname.lower().endswith('.dll'):
             continue
-        fname = fname + ".dll"
+        fname = fname + '.dll'
         if os.path.isfile(fname):
             results.append(fname)
     return results
@@ -54,7 +54,7 @@ def find_library(possible_lib_names, search_symbol, library_name):
         lib_names.append('lib' + lib_name)
 
     for name in lib_names:
-        if os.name == "nt":
+        if os.name == 'nt':
             paths.extend(find_library_nt(name))
         else:
             path = ctypes.util.find_library(name)

--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -228,14 +228,14 @@ class EventLoop(object):
 
 # from tornado
 def errno_from_exception(e):
-    """Provides the errno from an Exception object.
+    '''Provides the errno from an Exception object.
 
     There are cases that the errno attribute was not set so we pull
     the errno out of the args but if someone instatiates an Exception
     without any args you will get a tuple error. So this function
     abstracts all that behavior to give you a safe way to get the
     errno.
-    """
+    '''
 
     if hasattr(e, 'errno'):
         return e.errno

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -31,8 +31,8 @@ def main():
     shell.check_python()
 
     # fix py2exe
-    if hasattr(sys, "frozen") and sys.frozen in \
-            ("windows_exe", "console_exe"):
+    if hasattr(sys, 'frozen') and sys.frozen in \
+            ('windows_exe', 'console_exe'):
         p = os.path.dirname(os.path.abspath(sys.executable))
         os.chdir(p)
 
@@ -41,7 +41,7 @@ def main():
     daemon.daemon_exec(config)
 
     try:
-        logging.info("starting local at %s:%d" %
+        logging.info('starting local at %s:%d' %
                      (config['local_address'], config['local_port']))
 
         dns_resolver = asyncdns.DNSResolver()

--- a/shadowsocks/lru_cache.py
+++ b/shadowsocks/lru_cache.py
@@ -32,7 +32,7 @@ import time
 
 
 class LRUCache(collections.MutableMapping):
-    """This class is not thread safe"""
+    '''This class is not thread safe'''
 
     def __init__(self, timeout=60, close_callback=None, *args, **kwargs):
         self.timeout = timeout

--- a/shadowsocks/manager.py
+++ b/shadowsocks/manager.py
@@ -81,10 +81,10 @@ class Manager(object):
         port = int(config['server_port'])
         servers = self._relays.get(port, None)
         if servers:
-            logging.error("server already exists at %s:%d" % (config['server'],
+            logging.error('server already exists at %s:%d' % (config['server'],
                                                               port))
             return
-        logging.info("adding server at %s:%d" % (config['server'], port))
+        logging.info('adding server at %s:%d' % (config['server'], port))
         t = tcprelay.TCPRelay(config, self._dns_resolver, False,
                               self.stat_callback)
         u = udprelay.UDPRelay(config, self._dns_resolver, False,
@@ -97,13 +97,13 @@ class Manager(object):
         port = int(config['server_port'])
         servers = self._relays.get(port, None)
         if servers:
-            logging.info("removing server at %s:%d" % (config['server'], port))
+            logging.info('removing server at %s:%d' % (config['server'], port))
             t, u = servers
             t.close(next_tick=False)
             u.close(next_tick=False)
             del self._relays[port]
         else:
-            logging.error("server not exist at %s:%d" % (config['server'],
+            logging.error('server not exist at %s:%d' % (config['server'],
                                                          port))
 
     def handle_event(self, sock, fd, event):
@@ -132,8 +132,8 @@ class Manager(object):
 
     def _parse_command(self, data):
         # commands:
-        # add: {"server_port": 8000, "password": "foobar"}
-        # remove: {"server_port": 8000"}
+        # add: {'server_port': 8000, 'password': 'foobar'}
+        # remove: {'server_port': 8000'}
         data = common.to_str(data)
         parts = data.split(':', 1)
         if len(parts) < 2:

--- a/shadowsocks/server.py
+++ b/shadowsocks/server.py
@@ -68,7 +68,7 @@ def main():
         a_config = config.copy()
         a_config['server_port'] = int(port)
         a_config['password'] = password
-        logging.info("starting server at %s:%d" %
+        logging.info('starting server at %s:%d' %
                      (a_config['server'], int(port)))
         tcp_servers.append(tcprelay.TCPRelay(a_config, dns_resolver, False))
         udp_servers.append(udprelay.UDPRelay(a_config, dns_resolver, False))

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -366,7 +366,7 @@ class TCPRelayHandler(object):
         addrs = socket.getaddrinfo(ip, port, 0, socket.SOCK_STREAM,
                                    socket.SOL_TCP)
         if len(addrs) == 0:
-            raise Exception("getaddrinfo failed for %s:%d" % (ip, port))
+            raise Exception('getaddrinfo failed for %s:%d' % (ip, port))
         af, socktype, proto, canonname, sa = addrs[0]
         if self._forbidden_iplist:
             if common.to_str(sa[0]) in self._forbidden_iplist:
@@ -461,7 +461,7 @@ class TCPRelayHandler(object):
         return
 
     def _ota_chunk_data_gen(self, data):
-        data_len = struct.pack(">H", len(data))
+        data_len = struct.pack('>H', len(data))
         index = struct.pack('>I', self._ota_chunk_idx)
         key = self._encryptor.cipher_iv + index
         sha110 = onetimeauth_gen(data, key)
@@ -669,7 +669,7 @@ class TCPRelay(object):
         addrs = socket.getaddrinfo(listen_addr, listen_port, 0,
                                    socket.SOCK_STREAM, socket.SOL_TCP)
         if len(addrs) == 0:
-            raise Exception("can't get addrinfo for %s:%d" %
+            raise Exception('can\'t get addrinfo for %s:%d' %
                             (listen_addr, listen_port))
         af, socktype, proto, canonname, sa = addrs[0]
         server_socket = socket.socket(af, socktype, proto)

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -119,7 +119,7 @@ class UDPRelay(object):
         addrs = socket.getaddrinfo(self._listen_addr, self._listen_port, 0,
                                    socket.SOCK_DGRAM, socket.SOL_UDP)
         if len(addrs) == 0:
-            raise Exception("UDP can't get addrinfo for %s:%d" %
+            raise Exception('UDP can\'t get addrinfo for %s:%d' %
                             (self._listen_addr, self._listen_port))
         af, socktype, proto, canonname, sa = addrs[0]
         server_socket = socket.socket(af, socktype, proto)

--- a/tests/coverage_server.py
+++ b/tests/coverage_server.py
@@ -37,9 +37,9 @@ if __name__ == '__main__':
                 raise tornado.web.HTTPError(404)
 
     application = tornado.web.Application([
-        (r"/([a-zA-Z0-9\-_]+)", MainHandler),
+        (r'/([a-zA-Z0-9\-_]+)', MainHandler),
     ])
 
-    if __name__ == "__main__":
+    if __name__ == '__main__':
         application.listen(8888, address='127.0.0.1')
         tornado.ioloop.IOLoop.instance().start()

--- a/tests/nose_plugin.py
+++ b/tests/nose_plugin.py
@@ -20,7 +20,7 @@ from nose.plugins.base import Plugin
 
 class ExtensionPlugin(Plugin):
 
-    name = "ExtensionPlugin"
+    name = 'ExtensionPlugin'
 
     def options(self, parser, env):
         Plugin.options(self, parser, env)

--- a/tests/test_udp_src.py
+++ b/tests/test_udp_src.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     # make sure they're from the same source port
     assert result1 == result2
 
-    """
+    '''
     # Test 2: same source port IPv6
     # try again from the same port but IPv6
     sock_out = socks.socksocket(socket.AF_INET, socket.SOCK_DGRAM,
@@ -82,4 +82,4 @@ if __name__ == '__main__':
 
     sock_out.close()
     sock_in1.close()
-    """
+    '''


### PR DESCRIPTION
In some files, both single quote and double quotes are used in one line.

```python
logging.error("server not exist at %s:%d" % (config['server'], 
                                                                         port)
```

I converted those bad cases to only using single quote.