### PR TITLE
fix that autoban can not get ip when use ipv6

### DIFF
--- a/utils/autoban.py
+++ b/utils/autoban.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     banned = set()
     for line in sys.stdin:
         if 'can not parse header when' in line:
-            ip = line.split()[-1].split(':')[0]
+            ip = line.split()[-1].split(':')[-2]
             if ip not in ips:
                 ips[ip] = 1
                 print(ip)


### PR DESCRIPTION
When use ipv6,

```json
{
    "server":"::",
    ....
}
```


The ip format in log file is `2016-11-17 01:16:01 ERROR    can not parse header when handling connection from ::ffff:<ip>:<port>`.  
It causes `line.split()[-1].split(':')[0]` get empty str instead of ip.