### PR TITLE
update regex to support hostnames containing underscore

### DIFF
--- a/shadowsocks/asyncdns.py
+++ b/shadowsocks/asyncdns.py
@@ -29,7 +29,7 @@ from shadowsocks import common, lru_cache, eventloop, shell
 
 CACHE_SWEEP_INTERVAL = 30
 
-VALID_HOSTNAME = re.compile(br"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+VALID_HOSTNAME = re.compile(br"(?!-)[A-Z\d\-_]{1,63}(?<!-)$", re.IGNORECASE)
 
 common.patch_socket()
 


### PR DESCRIPTION
The current regex used to check if a hostname is valid can't recognise hostnames containing underscores and will generate an ERROR in the log.

``invalid hostname: ipv4_1-lagg0-c079.1.lax001.ix.nflxvideo.net when handling connection``

Not sure if this patch is the best fix but in my test it fixed this issue.

