### PR TITLE
parse dns_servre in config

### DIFF
--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -184,6 +184,8 @@ def check_config(config, is_local):
         if os.name != 'posix':
             logging.error('user can be used only on Unix')
             sys.exit(1)
+    if config.get('dns_server', None) is not None:
+        logging.info('Specified DNS server: %s' % config['dns_server'])
 
     encrypt.try_cipher(config['password'], config['method'])
 
@@ -297,6 +299,7 @@ def get_config(is_local):
     config['one_time_auth'] = config.get('one_time_auth', False)
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
+    config['dns_server'] = config.get('dns_server', None)
 
     logging.getLogger('').handlers = []
     logging.addLevelName(VERBOSE_LEVEL, 'VERBOSE')


### PR DESCRIPTION
In some special environment(https://github.com/shadowsocks/shadowsocks/issues/738), Server's DNS server is not able to resolve hostname quickly and successfully.

Add this to config for system DNS overriding. 