### PR TITLE
add simple ss-tunnel to shadowsocks for dns forward 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ htmlcov
 #vscode
 .idea
 .vscode
+
+#ss
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ htmlcov
 
 #Emacs
 .#*
+
+#vscode
+.idea
+.vscode

--- a/config.json.example
+++ b/config.json.example
@@ -7,7 +7,6 @@
     "method":"aes-256-cfb",
     "local_address":"127.0.0.1",
     "fast_open":false,
-    "both_tunnel_local":false,
     "tunnel_remote":"8.8.8.8",
     "tunnel_remote_port":53,
     "tunnel_port":53

--- a/config.json.example
+++ b/config.json.example
@@ -7,8 +7,8 @@
     "method":"aes-256-cfb",
     "local_address":"127.0.0.1",
     "fast_open":false,
-    "dns_service":false,
-    "dns_server":"8.8.8.8",
-    "dns_server_port":53,
-    "dns_local_port":53
+    "tunnel_service":false,
+    "tunnel_dns_server":"8.8.8.8",
+    "tunnel_dns_server_port":53,
+    "tunnel_dns_local_port":53
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,14 @@
+{
+    "server":"127.0.0.1",
+    "server_port":8388,
+    "local_port":1080,
+    "password":"password",
+    "timeout":600,
+    "method":"aes-256-cfb",
+    "local_address":"127.0.0.1",
+    "fast_open":false,
+    "dns_service":false,
+    "dns_server":"8.8.8.8",
+    "dns_server_port":53,
+    "dns_local_port":53
+}

--- a/config.json.example
+++ b/config.json.example
@@ -7,8 +7,8 @@
     "method":"aes-256-cfb",
     "local_address":"127.0.0.1",
     "fast_open":false,
-    "tunnel_service":false,
-    "tunnel_dns_server":"8.8.8.8",
-    "tunnel_dns_server_port":53,
-    "tunnel_dns_local_port":53
+    "both_tunnel_local":false,
+    "tunnel_remote":"8.8.8.8",
+    "tunnel_remote_port":53,
+    "tunnel_port":53
 }

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -159,11 +159,13 @@ def pack_addr(address):
         address = address[:255]  # TODO
     return b'\x03' + chr(len(address)) + address
 
+
 # add socks5 request header
-def add_header(address, port ,data):
+def add_header(address, port, data):
     header = b''
-    header = pack_addr(address) +  struct.pack('>H', port) + data
+    header = pack_addr(address) + struct.pack('>H', port) + data
     return header
+
 
 def parse_header(data):
     addrtype = ord(data[0])

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -159,6 +159,11 @@ def pack_addr(address):
         address = address[:255]  # TODO
     return b'\x03' + chr(len(address)) + address
 
+# add socks5 request header
+def add_header(address, port ,data):
+    header = b''
+    header = pack_addr(address) +  struct.pack('>H', port) + data
+    return header
 
 def parse_header(data):
     addrtype = ord(data[0])

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -162,7 +162,7 @@ def pack_addr(address):
 
 
 # add ss header
-def add_header(address, port, data):
+def add_header(address, port, data=b''):
     _data = b''
     _data = pack_addr(address) + struct.pack('>H', port) + data
     return _data

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -146,6 +146,7 @@ ADDRTYPE_MASK = 0xF
 
 def pack_addr(address):
     address_str = to_str(address)
+    address = to_bytes(address)
     for family in (socket.AF_INET, socket.AF_INET6):
         try:
             r = socket.inet_pton(family, address_str)
@@ -162,9 +163,9 @@ def pack_addr(address):
 
 # add ss header
 def add_header(address, port, data):
-    header = b''
-    header = pack_addr(address) + struct.pack('>H', port) + data
-    return header
+    _data = b''
+    _data = pack_addr(address) + struct.pack('>H', port) + data
+    return _data
 
 
 def parse_header(data):

--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -160,7 +160,7 @@ def pack_addr(address):
     return b'\x03' + chr(len(address)) + address
 
 
-# add socks5 request header
+# add ss header
 def add_header(address, port, data):
     header = b''
     header = pack_addr(address) + struct.pack('>H', port) + data

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -56,14 +56,14 @@ def main():
         _config = config.copy()
         _config["local_port"] = _config["tunnel_port"]
         logging.info("starting tcp tunnel at %s:%d forward to %s:%d" %
-                    (_config['local_address'], _config['local_port'],
-                    _config['tunnel_remote'], _config['tunnel_remote_port']))
+                     (_config['local_address'], _config['local_port'],
+                      _config['tunnel_remote'], _config['tunnel_remote_port']))
         tunnel_tcp_server = tcprelay.TCPRelay(_config, dns_resolver, True)
         tunnel_tcp_server.is_tunnel = True
         tunnel_tcp_server.add_to_loop(loop)
         logging.info("starting udp tunnel at %s:%d forward to %s:%d" %
-                    (_config['local_address'], _config['local_port'],
-                        _config['tunnel_remote'], _config['tunnel_remote_port']))
+                     (_config['local_address'], _config['local_port'],
+                      _config['tunnel_remote'], _config['tunnel_remote_port']))
         tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
         tunnel_udp_server.is_tunnel = True
         tunnel_udp_server.add_to_loop(loop)

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -51,14 +51,18 @@ def main():
     dns_resolver.add_to_loop(loop)
     tcp_server.add_to_loop(loop)
     udp_server.add_to_loop(loop)
+    has_tunnel = False
     if config["dns_service"]:
         tunnel_udp_server = get_tunnel_udp_server(config.copy(), dns_resolver)
         tunnel_udp_server.add_to_loop(loop)
+        has_tunnel = True
 
     def handler(signum, _):
         logging.warn('received SIGQUIT, doing graceful shutting down..')
         tcp_server.close(next_tick=True)
         udp_server.close(next_tick=True)
+        if has_tunnel:
+            tunnel_udp_server.close(next_tick=True)
     signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), handler)
 
     def int_handler(signum, _):

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -55,9 +55,15 @@ def main():
     if config["both_tunnel_local"]:
         _config = config.copy()
         _config["local_port"] = _config["tunnel_port"]
-        logging.info("starting tunnel at %s:%d forward to %s:%d" %
-                     (_config['local_address'], _config['local_port'],
-                      _config['tunnel_remote'], _config['tunnel_remote_port']))
+        logging.info("starting tcp tunnel at %s:%d forward to %s:%d" %
+                    (_config['local_address'], _config['local_port'],
+                    _config['tunnel_remote'], _config['tunnel_remote_port']))
+        tunnel_tcp_server = tcprelay.TCPRelay(_config, dns_resolver, True)
+        tunnel_tcp_server.is_tunnel = True
+        tunnel_tcp_server.add_to_loop(loop)
+        logging.info("starting udp tunnel at %s:%d forward to %s:%d" %
+                    (_config['local_address'], _config['local_port'],
+                        _config['tunnel_remote'], _config['tunnel_remote_port']))
         tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
         tunnel_udp_server.is_tunnel = True
         tunnel_udp_server.add_to_loop(loop)
@@ -69,6 +75,7 @@ def main():
         udp_server.close(next_tick=True)
         if has_tunnel:
             tunnel_udp_server.close(next_tick=True)
+            tunnel_tcp_server.close(next_tick=True)
     signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), handler)
 
     def int_handler(signum, _):

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -53,11 +53,12 @@ def main():
     has_tunnel = False
     # if both_tunnel_local is True then run tunnel_udp_server
     if config["both_tunnel_local"]:
-        config["local_port"] = config.copy()["tunnel_port"]
+        _config = config.copy()
+        _config["local_port"] = _config["tunnel_port"]
         logging.info("starting tunnel at %s:%d forward to %s:%d" %
-                     (config['local_address'], config['local_port'], config['tunnel_remote'],
-                      config['tunnel_remote_port']))
-        tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
+                     (_config['local_address'], _config['local_port'],
+                      _config['tunnel_remote'], _config['tunnel_remote_port']))
+        tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
         tunnel_udp_server.is_tunnel = True
         tunnel_udp_server.add_to_loop(loop)
         has_tunnel = True

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -50,32 +50,11 @@ def main():
     dns_resolver.add_to_loop(loop)
     tcp_server.add_to_loop(loop)
     udp_server.add_to_loop(loop)
-    has_tunnel = False
-    # if both_tunnel_local is True then run tunnel_udp_server
-    if config["both_tunnel_local"]:
-        _config = config.copy()
-        _config["local_port"] = _config["tunnel_port"]
-        logging.info("starting tcp tunnel at %s:%d forward to %s:%d" %
-                     (_config['local_address'], _config['local_port'],
-                      _config['tunnel_remote'], _config['tunnel_remote_port']))
-        tunnel_tcp_server = tcprelay.TCPRelay(_config, dns_resolver, True)
-        tunnel_tcp_server.is_tunnel = True
-        tunnel_tcp_server.add_to_loop(loop)
-        logging.info("starting udp tunnel at %s:%d forward to %s:%d" %
-                     (_config['local_address'], _config['local_port'],
-                      _config['tunnel_remote'], _config['tunnel_remote_port']))
-        tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
-        tunnel_udp_server.is_tunnel = True
-        tunnel_udp_server.add_to_loop(loop)
-        has_tunnel = True
 
     def handler(signum, _):
         logging.warn('received SIGQUIT, doing graceful shutting down..')
         tcp_server.close(next_tick=True)
         udp_server.close(next_tick=True)
-        if has_tunnel:
-            tunnel_udp_server.close(next_tick=True)
-            tunnel_tcp_server.close(next_tick=True)
     signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), handler)
 
     def int_handler(signum, _):

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -52,7 +52,7 @@ def main():
     tcp_server.add_to_loop(loop)
     udp_server.add_to_loop(loop)
     has_tunnel = False
-    if config["dns_service"]:
+    if config["tunnel_service"]:
         tunnel_udp_server = get_tunnel_udp_server(config.copy(), dns_resolver)
         tunnel_udp_server.add_to_loop(loop)
         has_tunnel = True

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -54,9 +54,9 @@ def main():
     # if both_tunnel_local is True then run tunnel_udp_server
     if config["both_tunnel_local"]:
         config["local_port"] = config.copy()["tunnel_port"]
-        logging.info("starting tunnel at %s:%d forward to %s:%d" % \
-            (config['local_address'], config['local_port'], config['tunnel_remote'], \
-                config['tunnel_remote_port']))
+        logging.info("starting tunnel at %s:%d forward to %s:%d" %
+                     (config['local_address'], config['local_port'], config['tunnel_remote'],
+                      config['tunnel_remote_port']))
         tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
         tunnel_udp_server.is_tunnel = True
         tunnel_udp_server.add_to_loop(loop)

--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -52,6 +52,7 @@ def main():
     tcp_server.add_to_loop(loop)
     udp_server.add_to_loop(loop)
     has_tunnel = False
+    # if tunnel_service is True then run tunnel_udp_server
     if config["tunnel_service"]:
         tunnel_udp_server = get_tunnel_udp_server(config.copy(), dns_resolver)
         tunnel_udp_server.add_to_loop(loop)

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -319,7 +319,6 @@ def get_config(is_local):
     config['tunnel_port'] = config.get('tunnel_port', 53)
     config['dns_server'] = config.get('dns_server', None)
 
-
     logging.getLogger('').handlers = []
     logging.addLevelName(VERBOSE_LEVEL, 'VERBOSE')
     if config['verbose'] >= 2:

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -310,7 +310,6 @@ def get_config(is_local):
     config['one_time_auth'] = config.get('one_time_auth', False)
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
-    config['both_tunnel_local'] = config.get('both_tunnel_local', False)
     config['tunnel_remote'] = \
         to_str(config.get('tunnel_remote', '8.8.8.8'))
     config['tunnel_remote_port'] = config.get('tunnel_remote_port', 53)

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -132,6 +132,13 @@ def check_config(config, is_local):
             sys.exit(2)
         else:
             config['server'] = to_str(config['server'])
+
+        if config.get('tunnel_remote', None) is None:
+            logging.error('tunnel_remote addr not specified')
+            print_local_help()
+            sys.exit(2)
+        else:
+            config['tunnel_remote'] = to_str(config['tunnel_remote'])
     else:
         config['server'] = to_str(config.get('server', '0.0.0.0'))
         try:

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -304,8 +304,8 @@ def get_config(is_local):
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
     config['both_tunnel_local'] = config.get('both_tunnel_local', False)
-    config['tunnel_server'] = \
-        to_str(config.get('tunnel_server', "8.8.8.8"))
+    config['tunnel_remote'] = \
+        to_str(config.get('tunnel_remote', '8.8.8.8'))
     config['tunnel_remote_port'] = config.get('tunnel_remote_port', 53)
     config['tunnel_port'] = config.get('tunnel_port', 53)
 

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -160,7 +160,8 @@ def check_config(config, is_local):
         config['server_port'] = int(config['server_port'])
 
     if 'tunnel_dns_server_port' in config:
-        config['tunnel_dns_server_port'] = int(config['tunnel_dns_server_port'])
+        config['tunnel_dns_server_port'] = \
+            int(config['tunnel_dns_server_port'])
     if 'tunnel_dns_local_port' in config:
         config['tunnel_dns_local_port'] = int(config['tunnel_dns_local_port'])
 
@@ -303,7 +304,8 @@ def get_config(is_local):
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
     config['tunnel_service'] = config.get('tunnel_service', False)
-    config['tunnel_dns_server'] = to_str(config.get('tunnel_dns_server', "8.8.8.8"))
+    config['tunnel_dns_server'] = \
+        to_str(config.get('tunnel_dns_server', "8.8.8.8"))
     config['tunnel_dns_server_port'] = config.get('tunnel_dns_server_port', 53)
     config['tunnel_dns_local_port'] = config.get('tunnel_dns_local_port', 53)
 

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -159,6 +159,11 @@ def check_config(config, is_local):
     if 'server_port' in config and type(config['server_port']) != list:
         config['server_port'] = int(config['server_port'])
 
+    if 'dns_server_port' in config:
+        config['dns_server_port'] = int(config['dns_server_port'])
+    if 'dns_local_port' in config:
+        config['dns_local_port'] = int(config['dns_local_port'])
+
     if config.get('local_address', '') in [b'0.0.0.0']:
         logging.warn('warning: local set to listen on 0.0.0.0, it\'s not safe')
     if config.get('server', '') in ['127.0.0.1', 'localhost']:
@@ -297,6 +302,10 @@ def get_config(is_local):
     config['one_time_auth'] = config.get('one_time_auth', False)
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
+    config['dns_service'] = config.get('dns_service', False)
+    config['dns_server'] = to_str(config.get('dns_server', "8.8.8.8"))
+    config['dns_server_port'] = config.get('dns_server_port', 53)
+    config['dns_local_port'] = config.get('dns_local_port', 53)
 
     logging.getLogger('').handlers = []
     logging.addLevelName(VERBOSE_LEVEL, 'VERBOSE')

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -159,10 +159,10 @@ def check_config(config, is_local):
     if 'server_port' in config and type(config['server_port']) != list:
         config['server_port'] = int(config['server_port'])
 
-    if 'dns_server_port' in config:
-        config['dns_server_port'] = int(config['dns_server_port'])
-    if 'dns_local_port' in config:
-        config['dns_local_port'] = int(config['dns_local_port'])
+    if 'tunnel_dns_server_port' in config:
+        config['tunnel_dns_server_port'] = int(config['tunnel_dns_server_port'])
+    if 'tunnel_dns_local_port' in config:
+        config['tunnel_dns_local_port'] = int(config['tunnel_dns_local_port'])
 
     if config.get('local_address', '') in [b'0.0.0.0']:
         logging.warn('warning: local set to listen on 0.0.0.0, it\'s not safe')
@@ -302,10 +302,10 @@ def get_config(is_local):
     config['one_time_auth'] = config.get('one_time_auth', False)
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
-    config['dns_service'] = config.get('dns_service', False)
-    config['dns_server'] = to_str(config.get('dns_server', "8.8.8.8"))
-    config['dns_server_port'] = config.get('dns_server_port', 53)
-    config['dns_local_port'] = config.get('dns_local_port', 53)
+    config['tunnel_service'] = config.get('tunnel_service', False)
+    config['tunnel_dns_server'] = to_str(config.get('tunnel_dns_server', "8.8.8.8"))
+    config['tunnel_dns_server_port'] = config.get('tunnel_dns_server_port', 53)
+    config['tunnel_dns_local_port'] = config.get('tunnel_dns_local_port', 53)
 
     logging.getLogger('').handlers = []
     logging.addLevelName(VERBOSE_LEVEL, 'VERBOSE')

--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -159,11 +159,11 @@ def check_config(config, is_local):
     if 'server_port' in config and type(config['server_port']) != list:
         config['server_port'] = int(config['server_port'])
 
-    if 'tunnel_dns_server_port' in config:
-        config['tunnel_dns_server_port'] = \
-            int(config['tunnel_dns_server_port'])
-    if 'tunnel_dns_local_port' in config:
-        config['tunnel_dns_local_port'] = int(config['tunnel_dns_local_port'])
+    if 'tunnel_remote_port' in config:
+        config['tunnel_remote_port'] = \
+            int(config['tunnel_remote_port'])
+    if 'tunnel_port' in config:
+        config['tunnel_port'] = int(config['tunnel_port'])
 
     if config.get('local_address', '') in [b'0.0.0.0']:
         logging.warn('warning: local set to listen on 0.0.0.0, it\'s not safe')
@@ -303,11 +303,11 @@ def get_config(is_local):
     config['one_time_auth'] = config.get('one_time_auth', False)
     config['prefer_ipv6'] = config.get('prefer_ipv6', False)
     config['server_port'] = config.get('server_port', 8388)
-    config['tunnel_service'] = config.get('tunnel_service', False)
-    config['tunnel_dns_server'] = \
-        to_str(config.get('tunnel_dns_server', "8.8.8.8"))
-    config['tunnel_dns_server_port'] = config.get('tunnel_dns_server_port', 53)
-    config['tunnel_dns_local_port'] = config.get('tunnel_dns_local_port', 53)
+    config['both_tunnel_local'] = config.get('both_tunnel_local', False)
+    config['tunnel_server'] = \
+        to_str(config.get('tunnel_server', "8.8.8.8"))
+    config['tunnel_remote_port'] = config.get('tunnel_remote_port', 53)
+    config['tunnel_port'] = config.get('tunnel_port', 53)
 
     logging.getLogger('').handlers = []
     logging.addLevelName(VERBOSE_LEVEL, 'VERBOSE')

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -106,6 +106,7 @@ class NoAcceptableMethods(Exception):
 
 
 class TCPRelayHandler(object):
+
     def __init__(self, server, fd_to_handlers, loop, local_sock, config,
                  dns_resolver, is_local):
         self._server = server
@@ -260,7 +261,7 @@ class TCPRelayHandler(object):
             tunnel_remote = self.tunnel_remote
             tunnel_remote_port = self.tunnel_remote_port
             data = common.add_header(tunnel_remote,
-                                        tunnel_remote_port, data)
+                                     tunnel_remote_port, data)
         if self._ota_enable_session:
             data = self._ota_chunk_data_gen(data)
         data = self._encryptor.encrypt(data)
@@ -368,7 +369,7 @@ class TCPRelayHandler(object):
             if not self.is_tunnel:
                 # forward address to remote
                 self._write_to_sock((b'\x05\x00\x00\x01'
-                                    b'\x00\x00\x00\x00\x10\x10'),
+                                     b'\x00\x00\x00\x00\x10\x10'),
                                     self._local_sock)
             # spec https://shadowsocks.org/en/spec/one-time-auth.html
             # ATYP & 0x10 == 0x10, then OTA is enabled.
@@ -508,7 +509,7 @@ class TCPRelayHandler(object):
                 tunnel_remote = self.tunnel_remote
                 tunnel_remote_port = self.tunnel_remote_port
                 data = common.add_header(tunnel_remote,
-                                            tunnel_remote_port, data)
+                                         tunnel_remote_port, data)
             if self._ota_enable_session:
                 data = self._ota_chunk_data_gen(data)
             data = self._encryptor.encrypt(data)
@@ -717,6 +718,7 @@ class TCPRelayHandler(object):
 
 
 class TCPRelay(object):
+
     def __init__(self, config, dns_resolver, is_local, stat_callback=None):
         self._config = config
         self._is_local = is_local

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -119,7 +119,7 @@ class TCPRelayHandler(object):
         self.tunnel_remote = config.get('tunnel_remote', "8.8.8.8")
         self.tunnel_remote_port = config.get('tunnel_remote_port', 53)
         self.tunnel_port = config.get('tunnel_port', 53)
-        self.is_tunnel = server.is_tunnel
+        self._is_tunnel = server._is_tunnel
 
         # TCP Relay works as either sslocal or ssserver
         # if is_local, this is sslocal
@@ -297,7 +297,7 @@ class TCPRelayHandler(object):
     @shell.exception_handle(self_=True, destroy=True, conn_err=True)
     def _handle_stage_addr(self, data):
         if self._is_local:
-            if self.is_tunnel:
+            if self._is_tunnel:
                 # add ss header to data
                 tunnel_remote = self.tunnel_remote
                 tunnel_remote_port = self.tunnel_remote_port
@@ -359,7 +359,7 @@ class TCPRelayHandler(object):
         self._stage = STAGE_DNS
         if self._is_local:
             # jump over socks5 response
-            if not self.is_tunnel:
+            if not self._is_tunnel:
                 # forward address to remote
                 self._write_to_sock((b'\x05\x00\x00\x01'
                                      b'\x00\x00\x00\x00\x10\x10'),
@@ -572,7 +572,7 @@ class TCPRelayHandler(object):
             return
         elif is_local and self._stage == STAGE_INIT:
             # jump over socks5 init
-            if self.is_tunnel:
+            if self._is_tunnel:
                 self._handle_stage_addr(data)
                 return
             else:
@@ -715,7 +715,7 @@ class TCPRelay(object):
         self._closed = False
         self._eventloop = None
         self._fd_to_handlers = {}
-        self.is_tunnel = False
+        self._is_tunnel = False
 
         self._timeout = config['timeout']
         self._timeouts = []  # a list for all the handlers

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -256,12 +256,6 @@ class TCPRelayHandler(object):
             else:
                 self._data_to_write_to_remote.append(data)
             return
-        if self.is_tunnel:
-            # add ss header to data
-            tunnel_remote = self.tunnel_remote
-            tunnel_remote_port = self.tunnel_remote_port
-            data = common.add_header(tunnel_remote,
-                                     tunnel_remote_port, data)
         if self._ota_enable_session:
             data = self._ota_chunk_data_gen(data)
         data = self._encryptor.encrypt(data)
@@ -504,12 +498,6 @@ class TCPRelayHandler(object):
 
     def _handle_stage_stream(self, data):
         if self._is_local:
-            if self.is_tunnel:
-                # add ss header to data
-                tunnel_remote = self.tunnel_remote
-                tunnel_remote_port = self.tunnel_remote_port
-                data = common.add_header(tunnel_remote,
-                                         tunnel_remote_port, data)
             if self._ota_enable_session:
                 data = self._ota_chunk_data_gen(data)
             data = self._encryptor.encrypt(data)

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -24,18 +24,19 @@ import logging
 import signal
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
-from shadowsocks import shell, daemon, eventloop, tcprelay, udprelay, asyncdns
+from shadowsocks import shell, daemon, eventloop, udprelay, asyncdns
+
 
 def get_tunnel_udp_server(config, dns_resolver):
     if config["dns_service"]:
         config["local_port"] = config.copy()["dns_local_port"]
         logging.info("starting tunnel at %s:%d" %
-                 (config['local_address'], config['local_port']))
+            (config['local_address'], config['local_port']))
     else:
         logging.info("dns_service is False")
-        return        
+        return
 
-    #tcp_server = tcprelay.TCPRelay(config, dns_resolver, True)
+    # tcp_server = tcprelay.TCPRelay(config, dns_resolver, True)
     tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
     tunnel_udp_server.is_tunnel = True
     return tunnel_udp_server
@@ -57,12 +58,12 @@ def main():
     tunnel_udp_server = get_tunnel_udp_server(config, dns_resolver)
     loop = eventloop.EventLoop()
     dns_resolver.add_to_loop(loop)
-    #tcp_server.add_to_loop(loop)
+    # tcp_server.add_to_loop(loop)
     tunnel_udp_server.add_to_loop(loop)
 
     def handler(signum, _):
         logging.warn('received SIGQUIT, doing graceful shutting down..')
-        #tcp_server.close(next_tick=True)
+        # tcp_server.close(next_tick=True)
         tunnel_udp_server.close(next_tick=True)
     signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), handler)
 

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -28,12 +28,12 @@ from shadowsocks import shell, daemon, eventloop, udprelay, asyncdns
 
 
 def get_tunnel_udp_server(config, dns_resolver):
-    if config["dns_service"]:
-        config["local_port"] = config.copy()["dns_local_port"]
+    if config["tunnel_service"]:
+        config["local_port"] = config.copy()["tunnel_dns_local_port"]
         logging.info("starting tunnel at %s:%d" %
             (config['local_address'], config['local_port']))
     else:
-        logging.info("dns_service is False")
+        logging.info("tunnel_service is False")
         return
 
     # tcp_server = tcprelay.TCPRelay(config, dns_resolver, True)

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -44,9 +44,9 @@ def main():
     dns_resolver.add_to_loop(loop)
     # tcp_server.add_to_loop(loop)
     config["local_port"] = config.copy()["tunnel_port"]
-    logging.info("starting tunnel at %s:%d forward to %s:%d" % \
-        (config['local_address'], config['local_port'], config['tunnel_remote'], \
-            config['tunnel_remote_port']))
+    logging.info("starting tunnel at %s:%d forward to %s:%d" %
+                 (config['local_address'], config['local_port'], config['tunnel_remote'],
+                  config['tunnel_remote_port']))
     tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
     tunnel_udp_server.is_tunnel = True
     tunnel_udp_server.add_to_loop(loop)

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -43,11 +43,12 @@ def main():
     loop = eventloop.EventLoop()
     dns_resolver.add_to_loop(loop)
     # tcp_server.add_to_loop(loop)
-    config["local_port"] = config.copy()["tunnel_port"]
+    _config = config.copy()
+    _config["local_port"] = _config["tunnel_port"]
     logging.info("starting tunnel at %s:%d forward to %s:%d" %
-                 (config['local_address'], config['local_port'], config['tunnel_remote'],
-                  config['tunnel_remote_port']))
-    tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
+                 (_config['local_address'], _config['local_port'],
+                     _config['tunnel_remote'], _config['tunnel_remote_port']))
+    tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
     tunnel_udp_server.is_tunnel = True
     tunnel_udp_server.add_to_loop(loop)
 

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -28,14 +28,9 @@ from shadowsocks import shell, daemon, eventloop, udprelay, asyncdns
 
 
 def get_tunnel_udp_server(config, dns_resolver):
-    if config["tunnel_service"]:
-        config["local_port"] = config.copy()["tunnel_dns_local_port"]
-        logging.info("starting tunnel at %s:%d" % \
-            (config['local_address'], config['local_port']))
-    else:
-        logging.info("tunnel_service is False")
-        return
-
+    config["local_port"] = config.copy()["tunnel_port"]
+    logging.info("starting tunnel at %s:%d" % \
+        (config['local_address'], config['local_port']))
     # tcp_server = tcprelay.TCPRelay(config, dns_resolver, True)
     tunnel_udp_server = udprelay.UDPRelay(config, dns_resolver, True)
     tunnel_udp_server.is_tunnel = True

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -30,7 +30,7 @@ from shadowsocks import shell, daemon, eventloop, udprelay, asyncdns
 def get_tunnel_udp_server(config, dns_resolver):
     if config["tunnel_service"]:
         config["local_port"] = config.copy()["tunnel_dns_local_port"]
-        logging.info("starting tunnel at %s:%d" %
+        logging.info("starting tunnel at %s:%d" % \
             (config['local_address'], config['local_port']))
     else:
         logging.info("tunnel_service is False")

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -63,7 +63,7 @@ def main():
     def handler(signum, _):
         logging.warn('received SIGQUIT, doing graceful shutting down..')
         #tcp_server.close(next_tick=True)
-        udp_server.close(next_tick=True)
+        tunnel_udp_server.close(next_tick=True)
     signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), handler)
 
     def int_handler(signum, _):

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -55,6 +55,8 @@ def main():
     config = shell.get_config(True)
     daemon.daemon_exec(config)
     dns_resolver = asyncdns.DNSResolver()
+    # if running tunnel then update tunnel_service to True
+    config["tunnel_service"] = True
     tunnel_udp_server = get_tunnel_udp_server(config, dns_resolver)
     loop = eventloop.EventLoop()
     dns_resolver.add_to_loop(loop)

--- a/shadowsocks/tunnel.py
+++ b/shadowsocks/tunnel.py
@@ -48,13 +48,13 @@ def main():
                  (_config['local_address'], _config['local_port'],
                   _config['tunnel_remote'], _config['tunnel_remote_port']))
     tunnel_tcp_server = tcprelay.TCPRelay(_config, dns_resolver, True)
-    tunnel_tcp_server.is_tunnel = True
+    tunnel_tcp_server._is_tunnel = True
     tunnel_tcp_server.add_to_loop(loop)
     logging.info("starting udp tunnel at %s:%d forward to %s:%d" %
                  (_config['local_address'], _config['local_port'],
                      _config['tunnel_remote'], _config['tunnel_remote_port']))
     tunnel_udp_server = udprelay.UDPRelay(_config, dns_resolver, True)
-    tunnel_udp_server.is_tunnel = True
+    tunnel_udp_server._is_tunnel = True
     tunnel_udp_server.add_to_loop(loop)
 
     def handler(signum, _):

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -95,7 +95,6 @@ class UDPRelay(object):
             self._listen_port = config['server_port']
             self._remote_addr = None
             self._remote_port = None
-        self.both_tunnel_local = config.get('both_tunnel_local', False)
         self.tunnel_remote = config.get('tunnel_remote', "8.8.8.8")
         self.tunnel_remote_port = config.get('tunnel_remote_port', 53)
         self.tunnel_port = config.get('tunnel_port', 53)

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -158,7 +158,7 @@ class UDPRelay(object):
             self._stat_callback(self._listen_port, len(data))
         if self._is_local:
             if self.is_tunnel:
-                # add socks5 header to data
+                # add ss header to data
                 tunnel_remote = self.tunnel_remote
                 tunnel_remote_port = self.tunnel_remote_port
                 data = common.add_header(tunnel_remote,
@@ -282,7 +282,7 @@ class UDPRelay(object):
                 return
             addrtype, dest_addr, dest_port, header_length = header_result
             if self.is_tunnel:
-                # remove socks5 header
+                # remove ss header
                 response = data[7:]
             else:
                 response = b'\x00\x00\x00' + data

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -82,6 +82,7 @@ def client_key(source_addr, server_af):
 
 
 class UDPRelay(object):
+
     def __init__(self, config, dns_resolver, is_local, stat_callback=None):
         self._config = config
         if is_local:
@@ -160,8 +161,8 @@ class UDPRelay(object):
                 # add socks5 header to data
                 tunnel_remote = self.tunnel_remote
                 tunnel_remote_port = self.tunnel_remote_port
-                data = common.add_header(tunnel_remote, \
-                    tunnel_remote_port, data)
+                data = common.add_header(tunnel_remote,
+                                         tunnel_remote_port, data)
             else:
                 frag = common.ord(data[2])
                 if frag != 0:
@@ -183,8 +184,8 @@ class UDPRelay(object):
         if header_result is None:
             return
         addrtype, dest_addr, dest_port, header_length = header_result
-        logging.info("udp data to %s:%d from %s:%d" \
-            %(dest_addr, dest_port, r_addr[0], r_addr[1]))
+        logging.info("udp data to %s:%d from %s:%d"
+                     % (dest_addr, dest_port, r_addr[0], r_addr[1]))
         if self._is_local:
             server_addr, server_port = self._get_a_server()
         else:
@@ -287,8 +288,8 @@ class UDPRelay(object):
                 response = b'\x00\x00\x00' + data
         client_addr = self._client_fd_to_server_addr.get(sock.fileno())
         if client_addr:
-            logging.debug("send udp response to %s:%d" \
-                %(client_addr[0], client_addr[1]))
+            logging.debug("send udp response to %s:%d"
+                          % (client_addr[0], client_addr[1]))
             self._server_socket.sendto(response, client_addr)
         else:
             # this packet is from somewhere else we know

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -98,7 +98,7 @@ class UDPRelay(object):
         self.tunnel_remote = config.get('tunnel_remote', "8.8.8.8")
         self.tunnel_remote_port = config.get('tunnel_remote_port', 53)
         self.tunnel_port = config.get('tunnel_port', 53)
-        self.is_tunnel = False
+        self._is_tunnel = False
         self._dns_resolver = dns_resolver
         self._password = common.to_bytes(config['password'])
         self._method = config['method']
@@ -156,7 +156,7 @@ class UDPRelay(object):
         if self._stat_callback:
             self._stat_callback(self._listen_port, len(data))
         if self._is_local:
-            if self.is_tunnel:
+            if self._is_tunnel:
                 # add ss header to data
                 tunnel_remote = self.tunnel_remote
                 tunnel_remote_port = self.tunnel_remote_port
@@ -280,7 +280,7 @@ class UDPRelay(object):
             if header_result is None:
                 return
             addrtype, dest_addr, dest_port, header_length = header_result
-            if self.is_tunnel:
+            if self._is_tunnel:
                 # remove ss header
                 response = data[header_length:]
             else:

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -94,10 +94,10 @@ class UDPRelay(object):
             self._listen_port = config['server_port']
             self._remote_addr = None
             self._remote_port = None
-        self.tunnel_service = config.get('tunnel_service', False)
-        self.tunnel_dns_server = config.get('tunnel_dns_server', "8.8.8.8")
-        self.tunnel_dns_server_port = config.get('tunnel_dns_server_port', 53)
-        self.tunnel_dns_local_port = config.get('tunnel_dns_local_port', 53)
+        self.both_tunnel_local = config.get('both_tunnel_local', False)
+        self.tunnel_remote = config.get('tunnel_remote', "8.8.8.8")
+        self.tunnel_remote_port = config.get('tunnel_remote_port', 53)
+        self.tunnel_port = config.get('tunnel_port', 53)
         self.is_tunnel = False
         self._dns_resolver = dns_resolver
         self._password = common.to_bytes(config['password'])
@@ -158,10 +158,10 @@ class UDPRelay(object):
         if self._is_local:
             if self.is_tunnel:
                 # add socks5 header to data
-                tunnel_dns_server = self.tunnel_dns_server
-                tunnel_dns_server_port = self.tunnel_dns_server_port
-                data = common.add_header(tunnel_dns_server, \
-                    tunnel_dns_server_port, data)
+                tunnel_remote = self.tunnel_remote
+                tunnel_remote_port = self.tunnel_remote_port
+                data = common.add_header(tunnel_remote, \
+                    tunnel_remote_port, data)
             else:
                 frag = common.ord(data[2])
                 if frag != 0:

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -160,7 +160,8 @@ class UDPRelay(object):
                 # add socks5 header to data
                 tunnel_dns_server = self.tunnel_dns_server
                 tunnel_dns_server_port = self.tunnel_dns_server_port
-                data = common.add_header(tunnel_dns_server, tunnel_dns_server_port, data)
+                data = common.add_header(tunnel_dns_server, \
+                    tunnel_dns_server_port, data)
             else:
                 frag = common.ord(data[2])
                 if frag != 0:
@@ -182,7 +183,7 @@ class UDPRelay(object):
         if header_result is None:
             return
         addrtype, dest_addr, dest_port, header_length = header_result
-        logging.info("udp data to %s:%d from %s:%d" 
+        logging.info("udp data to %s:%d from %s:%d" \
             %(dest_addr, dest_port, r_addr[0], r_addr[1]))
         if self._is_local:
             server_addr, server_port = self._get_a_server()
@@ -286,7 +287,7 @@ class UDPRelay(object):
                 response = b'\x00\x00\x00' + data
         client_addr = self._client_fd_to_server_addr.get(sock.fileno())
         if client_addr:
-            logging.debug("send udp response to %s:%d" 
+            logging.debug("send udp response to %s:%d" \
                 %(client_addr[0], client_addr[1]))
             self._server_socket.sendto(response, client_addr)
         else:

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -94,10 +94,10 @@ class UDPRelay(object):
             self._listen_port = config['server_port']
             self._remote_addr = None
             self._remote_port = None
-        self.dns_service = config.get('dns_service', False)
-        self.dns_server = config.get('dns_server', "8.8.8.8")
-        self.dns_server_port = config.get('dns_server_port', 53)
-        self.dns_local_port = config.get('dns_local_port', 53)
+        self.tunnel_service = config.get('tunnel_service', False)
+        self.tunnel_dns_server = config.get('tunnel_dns_server', "8.8.8.8")
+        self.tunnel_dns_server_port = config.get('tunnel_dns_server_port', 53)
+        self.tunnel_dns_local_port = config.get('tunnel_dns_local_port', 53)
         self.is_tunnel = False
         self._dns_resolver = dns_resolver
         self._password = common.to_bytes(config['password'])
@@ -158,9 +158,9 @@ class UDPRelay(object):
         if self._is_local:
             if self.is_tunnel:
                 # add socks5 header to data
-                dns_server = self.dns_server
-                dns_server_port = self.dns_server_port
-                data = common.add_header(dns_server, dns_server_port, data)
+                tunnel_dns_server = self.tunnel_dns_server
+                tunnel_dns_server_port = self.tunnel_dns_server_port
+                data = common.add_header(tunnel_dns_server, tunnel_dns_server_port, data)
             else:
                 frag = common.ord(data[2])
                 if frag != 0:

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -94,6 +94,11 @@ class UDPRelay(object):
             self._listen_port = config['server_port']
             self._remote_addr = None
             self._remote_port = None
+        self.dns_service = config.get('dns_service', False)
+        self.dns_server = config.get('dns_server', "8.8.8.8")
+        self.dns_server_port = config.get('dns_server_port', 53)
+        self.dns_local_port = config.get('dns_local_port', 53)
+        self.is_tunnel = False
         self._dns_resolver = dns_resolver
         self._password = common.to_bytes(config['password'])
         self._method = config['method']
@@ -151,12 +156,18 @@ class UDPRelay(object):
         if self._stat_callback:
             self._stat_callback(self._listen_port, len(data))
         if self._is_local:
-            frag = common.ord(data[2])
-            if frag != 0:
-                logging.warn('UDP drop a message since frag is not 0')
-                return
+            if self.is_tunnel:
+                #add socks5 header to data
+                dns_server = self.dns_server
+                dns_server_port = self.dns_server_port
+                data = common.add_header(dns_server, dns_server_port, data)
             else:
-                data = data[3:]
+                frag = common.ord(data[2])
+                if frag != 0:
+                    logging.warn('UDP drop a message since frag is not 0')
+                    return
+                else:
+                    data = data[3:]
         else:
             data, key, iv = encrypt.dencrypt_all(self._password,
                                                  self._method,
@@ -171,7 +182,7 @@ class UDPRelay(object):
         if header_result is None:
             return
         addrtype, dest_addr, dest_port, header_length = header_result
-
+        logging.info("udp data to %s:%d from %s:%d" %(dest_addr, dest_port, r_addr[0], r_addr[1]))
         if self._is_local:
             server_addr, server_port = self._get_a_server()
         else:
@@ -267,9 +278,14 @@ class UDPRelay(object):
             if header_result is None:
                 return
             addrtype, dest_addr, dest_port, header_length = header_result
-            response = b'\x00\x00\x00' + data
+            if self.is_tunnel:
+                # remove socks5 header
+                response = data[7:]
+            else:
+                response = b'\x00\x00\x00' + data
         client_addr = self._client_fd_to_server_addr.get(sock.fileno())
         if client_addr:
+            logging.debug("send udp response to %s:%d" %(client_addr[0], client_addr[1]))
             self._server_socket.sendto(response, client_addr)
         else:
             # this packet is from somewhere else we know

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -157,7 +157,7 @@ class UDPRelay(object):
             self._stat_callback(self._listen_port, len(data))
         if self._is_local:
             if self.is_tunnel:
-                #add socks5 header to data
+                # add socks5 header to data
                 dns_server = self.dns_server
                 dns_server_port = self.dns_server_port
                 data = common.add_header(dns_server, dns_server_port, data)
@@ -182,7 +182,8 @@ class UDPRelay(object):
         if header_result is None:
             return
         addrtype, dest_addr, dest_port, header_length = header_result
-        logging.info("udp data to %s:%d from %s:%d" %(dest_addr, dest_port, r_addr[0], r_addr[1]))
+        logging.info("udp data to %s:%d from %s:%d" 
+            %(dest_addr, dest_port, r_addr[0], r_addr[1]))
         if self._is_local:
             server_addr, server_port = self._get_a_server()
         else:
@@ -285,7 +286,8 @@ class UDPRelay(object):
                 response = b'\x00\x00\x00' + data
         client_addr = self._client_fd_to_server_addr.get(sock.fileno())
         if client_addr:
-            logging.debug("send udp response to %s:%d" %(client_addr[0], client_addr[1]))
+            logging.debug("send udp response to %s:%d" 
+                %(client_addr[0], client_addr[1]))
             self._server_socket.sendto(response, client_addr)
         else:
             # this packet is from somewhere else we know

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -283,7 +283,7 @@ class UDPRelay(object):
             addrtype, dest_addr, dest_port, header_length = header_result
             if self.is_tunnel:
                 # remove ss header
-                response = data[7:]
+                response = data[header_length:]
             else:
                 response = b'\x00\x00\x00' + data
         client_addr = self._client_fd_to_server_addr.get(sock.fileno())


### PR DESCRIPTION
add simple ss-tunnel to shadowsocks for dns forward (seem ss-tunnel of ss-libev)

see :  https://github.com/shadowsocks/shadowsocks/issues/760

1. add tunnel.py file for tcp/udp forward (seem ss-tunnel of ss-libev).

2. update `self._is_tunnel`  and other code to `udprelay.py` `tcprelay.py`.

2. add `add_header` to common.py for add ss_header.

3. add config.json.example to shadowsocks.

4. update `address = to_bytes(address)` to `pack_addr` from common.py (fix a error when the address is a str domain).

5. update to `local.py`  `shell.py` for tunnel.