### PR TITLE
update openssl_lib's name for the new openssl-1.1 dll (just for windows)

### DIFF
--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -26,6 +26,7 @@ def find_library_nt(name):
     # ctypes.util.find_library just returns first result he found
     # but we want to try them all
     # because on Windows, users may have both 32bit and 64bit version installed
+    import glob
     results = []
     for directory in os.environ['PATH'].split(os.pathsep):
         fname = os.path.join(directory, name)
@@ -33,9 +34,10 @@ def find_library_nt(name):
             results.append(fname)
         if fname.lower().endswith(".dll"):
             continue
-        fname += ".dll"
-        if os.path.isfile(fname):
-            results.append(fname)
+        fname += "*.dll"
+        files = glob.glob(fname)
+        if files:
+            results.extend(files)
     return results
 
 


### PR DESCRIPTION
the new openssl's dll(1.1) is rename to libcrypto-1_1-x64.dll and libcrypto-1_1.dll


see: https://github.com/shadowsocks/shadowsocks/issues/783#issuecomment-287532407