### PR TITLE
Add whitelist option for autoban.py

### DIFF
--- a/utils/autoban.py
+++ b/utils/autoban.py
@@ -33,12 +33,16 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--count', default=3, type=int,
                         help='with how many failure times it should be '
                              'considered as an attack')
+    parser.add_argument('-wl', '--whitelist', action='append',
+                        help='whiltelist ip that shall not be banned.')
     config = parser.parse_args()
     ips = {}
     banned = set()
     for line in sys.stdin:
         if 'can not parse header when' in line:
             ip = line.split()[-1].split(':')[-2]
+            if ip in config.whitelist:
+                continue
             if ip not in ips:
                 ips[ip] = 1
                 print(ip)


### PR DESCRIPTION
So that IPs given in the ```whitelist```options will always be ignored and not even processed. Useful in preventing the user's client IP from being banned by the server.