### PR TITLE
reply stat to ping cmd as the spec describe.

### DIFF
--- a/shadowsocks/manager.py
+++ b/shadowsocks/manager.py
@@ -92,6 +92,7 @@ class Manager(object):
         t.add_to_loop(self._loop)
         u.add_to_loop(self._loop)
         self._relays[port] = (t, u)
+        self._statistics[port] = 0
 
     def remove_port(self, config):
         port = int(config['server_port'])
@@ -102,6 +103,7 @@ class Manager(object):
             t.close(next_tick=False)
             u.close(next_tick=False)
             del self._relays[port]
+            del self._statistics[port]
         else:
             logging.error("server not exist at %s:%d" % (config['server'],
                                                          port))
@@ -126,7 +128,8 @@ class Manager(object):
                         self.remove_port(a_config)
                         self._send_control_data(b'ok')
                     elif command == 'ping':
-                        self._send_control_data(b'pong')
+                        # self._send_control_data(b'pong')
+                        self._send_stat_data()
                     else:
                         logging.error('unknown command %s', command)
 
@@ -152,6 +155,9 @@ class Manager(object):
         self._statistics[port] += data_len
 
     def handle_periodic(self):
+        pass
+
+    def _send_stat_data(self):
         r = {}
         i = 0
 
@@ -172,7 +178,7 @@ class Manager(object):
                 i = 0
         if len(r) > 0:
             send_data(r)
-        self._statistics.clear()
+        # self._statistics.clear()
 
     def _send_control_data(self, data):
         if not self._control_client_addr:


### PR DESCRIPTION
Change for making the python version and libev version the same
discipline, easy maintenance for shadowsocks-manager

- reply stat but not pong as the spec description. keeping the same with
  the libev version.
```
    To receive a pong:

    ping
    Shadowsocks will send back transfer statistics:

    stat: {"8001":11370}
```
- change the stat data as the sum of the port realflow, keeping the same
  with the libev version
- reply the stat even if the port flow is zero, more fit as a pong
  action