### PR TITLE
Fix udp dns issue under python3

### DIFF
--- a/shadowsocks/shell.py
+++ b/shadowsocks/shell.py
@@ -199,6 +199,8 @@ def check_config(config, is_local):
     if config.get('dns_server', None) is not None:
         if type(config['dns_server']) != list:
             config['dns_server'] = to_str(config['dns_server'])
+        else:
+            config['dns_server'] = [to_str(ds) for ds in config['dns_server']]
         logging.info('Specified DNS server: %s' % config['dns_server'])
 
     config['crypto_path'] = {'openssl': config['libopenssl'],


### PR DESCRIPTION
str is not bytes under python3, if dns config is a list, will cause asyncdns.py failed:

asyncdns.py:
..........

    def handle_event(self, sock, fd, event):
        if sock != self._sock:
            return
        if event & eventloop.POLL_ERR:
       ...........
        else:
            data, addr = sock.recvfrom(1024)
            if addr[0] not in self._servers:
                logging.warn('received a packet other than our dns')
                return
            self._handle_data(data)