### PR TITLE
fix `TypeError: a bytes-like object is required, not "str"` error whe…

### DIFF
--- a/shadowsocks/manager.py
+++ b/shadowsocks/manager.py
@@ -45,6 +45,8 @@ class Manager(object):
         self._control_client_addr = None
         try:
             manager_address = config['manager_address']
+            if hasattr(manager_address, 'decode'):
+                manager_address = manager_address.decode('utf-8')
             if ':' in manager_address:
                 addr = manager_address.rsplit(':', 1)
                 addr = addr[0], int(addr[1])


### PR DESCRIPTION
## Describe

fix `TypeError: a bytes-like object is required, not "str"` error when handling manager_address argument in the Manager.__init__ method of the manager module.

## Example Configuration

```js
{
    "server":"127.0.0.1",
    "server_port":12345,
    "password":"12345678",
    "method":"aes-256-cfb",
    "fast_open":false,
    "manager_address":"127.0.0.1:6001",
}
```

## Traceback

```sh
Traceback (most recent call last):
  File "/bin/ssserver", line 11, in <module>
    load_entry_point('shadowsocks', 'console_scripts', 'ssserver')()
  File "shadowsocks/server.py", line 54, in main
    manager.run(config)
  File "shadowsocks/manager.py", line 199, in run
    Manager(config).run()
  File "shadowsocks/manager.py", line 48, in __init__
    if ':' in manager_address:
TypeError: a bytes-like object is required, not 'str'
```

## Fix

add the judgement of decode function for handle the str problem.

```py
if hasattr(manager_address, 'decode'):
    manager_address = manager_address.decode('utf-8')
```